### PR TITLE
Fix missing ansible_vault secret

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -9,5 +9,6 @@
       - name: git.openstack.org/openstack/openstack-ansible
         override-checkout: stable/rocky
     secrets:
+      - ansible_vault
       - site_bastion
     nodeset: centos-7-1vcpu

--- a/playbooks/run.yaml
+++ b/playbooks/run.yaml
@@ -1,11 +1,5 @@
 - hosts: all
   tasks:
-    - name: Ensure /etc/openstack_deploy directory exists
-      become: true
-      file:
-        dest: /etc/openstack_deploy
-        state: directory
-
     - name: Symlink /etc/openstack_deploy directory
       become: true
       file:


### PR DESCRIPTION
Also, remove need to create /etc/openstack_deploy folder. This wasn't
actually the fix.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>