### PR TITLE
Setup ANSIBLE_CALLBACK_PLUGINS variable for ARA

### DIFF
--- a/playbooks/run.yaml
+++ b/playbooks/run.yaml
@@ -33,6 +33,7 @@
         chdir: "{{ zuul.projects['git.openstack.org/openstack/openstack-ansible'].src_dir }}/playbooks"
       environment:
         ANSIBLE_VAULT_PASSWORD_FILE: "{{ vault_private_key_tmp.path }}"
+        ANSIBLE_CALLBACK_PLUGINS: /etc/ansible/roles/plugins/callback:/opt/ansible-runtime/lib/python2.7/site-packages/ara/plugins/callbacks
         SSH_AUTH_SOCK: "{{ site_bastion.ssh_auth_sock }}"
 
     - name: Remove vault private key from disk


### PR DESCRIPTION
We need to ensure the ara plugin is in the proper path for ansible.
Long term, we should see if we can add these settings into ansible.cfg
file.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>