### PR TITLE
Use become for ara generate html

### DIFF
--- a/playbooks/post.yaml
+++ b/playbooks/post.yaml
@@ -6,6 +6,7 @@
         state: directory
 
     - name: Generate ARA HTML output
+      become: true
       command: "/opt/ansible-runtime/bin/ara generate html {{ ansible_user_dir }}/zuul-output/logs/logs/ara-report"
 
     # TODO: Migrate to fetch-zuul-logs when


### PR DESCRIPTION
We run openstack-ansible as root, so we also need to use root for ara to
access the database.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>