### PR TITLE
Create bastion nodeset for job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -12,4 +12,7 @@
       - ansible_vault
       - site_bastion
     timeout: 3600
-    nodeset: centos-7-1vcpu
+    nodeset:
+      nodes:
+        - name: bastion
+          label: ansible-centos-7-1vcpu

--- a/playbooks/post.yaml
+++ b/playbooks/post.yaml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: bastion
   tasks:
     - name: Ensure ara-report directory exists
       file:

--- a/playbooks/pre.yaml
+++ b/playbooks/pre.yaml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: bastion
   tasks:
     - name: Run bindep role
       include_role:

--- a/playbooks/run.yaml
+++ b/playbooks/run.yaml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: bastion
   tasks:
     - name: Symlink /etc/openstack_deploy directory
       become: true


### PR DESCRIPTION
A cosmetic change to rename centos-7 to bastion for hostname.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>