### PR TITLE
Bump job timeout to 5400

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -11,7 +11,7 @@
     secrets:
       - ansible_vault
       - site_bastion
-    timeout: 3600
+    timeout: 5400
     nodeset:
       nodes:
         - name: bastion


### PR DESCRIPTION
Seems limestone takes a little longer for OSA to run.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>