### PR TITLE
Set openstack_service_setup_host for network failure

### DIFF
--- a/openstack_deploy/user_variables.yml
+++ b/openstack_deploy/user_variables.yml
@@ -1,3 +1,8 @@
 ---
 debug: false
 install_method: source
+
+# Use the utility container for host checks as deployment host doesn't have
+# HTTP access to br-mgmt network.
+openstack_service_setup_host: "{{ groups['utility_all'][0] }}"
+


### PR DESCRIPTION
HTTP requests from bastion host to br-mgmt network isn't setup, we can
use the utility container instead to hand this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>