### PR TITLE
Add openstack_service_setup_host_python_interpreter setting

### DIFF
--- a/openstack_deploy/user_variables.yml
+++ b/openstack_deploy/user_variables.yml
@@ -5,6 +5,7 @@ install_method: source
 # Use the utility container for host checks as deployment host doesn't have
 # HTTP access to br-mgmt network.
 openstack_service_setup_host: "{{ groups['utility_all'][0] }}"
+openstack_service_setup_host_python_interpreter: "/openstack/venvs/utility-{{ openstack_release }}/bin/python"
 
 # Because we override openstack_service_setup_host above to the utility
 # container, we also need to ensure that shade is installed to keep ansible


### PR DESCRIPTION
We need to tell each service which python version to use, this is
because shade is installed into a venv.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>